### PR TITLE
Added optional device_class field and updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,12 @@ To enable it, add the following lines to your `configuration.yaml`:
 sensor:
   - platform: prometheus_query
     name: Temperature Pisa
-    unique_id: sensoEntityId
+    unique_id: sensorEntityId
     prometheus_url: http://localhost:9090
     prometheus_query: temperature{location="Pisa",province="PI",region="Tuscany"}
     unit_of_measurement: "°C"
     state_class: total_increasing
+    device_class: temperature
 ```
 
 ### Configuration Variables

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ To enable it, add the following lines to your `configuration.yaml`:
 sensor:
   - platform: prometheus_query
     name: Temperature Pisa
-    entity_id: sensoEntityId
+    unique_id: sensoEntityId
     prometheus_url: http://localhost:9090
     prometheus_query: temperature{location="Pisa",province="PI",region="Tuscany"}
     unit_of_measurement: "°C"
@@ -24,9 +24,9 @@ sensor:
   
   (string)(Required) Name of the sensor..
 
-- entity_id: sensor Entity Id (See home assitant docs)
+- unique_id: sensor Entity Id (See home assitant docs)
   
-  (string)(Required if  using more than one senso) Id of the sensor..
+  (string)(Required if using more than one sensor) Id of the sensor..
 
 - prometheus_url
   
@@ -43,5 +43,10 @@ sensor:
 - state_class
   
   (string)(Optional) Defines the type of sensor. `measurement` for metrics that are gauges,`total_increasing` for metrics that are counters.
+
+- device_class
+
+  (string)(Optional) Defines the type of device. see [Here](https://github.com/home-assistant/core/blob/master/homeassistant/components/sensor/__init__.py) for device types, such as `energy`, `battery`, `temperature`
+
 
 It's a custom component so it must be downloaded under /custom_components folder.

--- a/custom_components/prometheus_query/sensor.py
+++ b/custom_components/prometheus_query/sensor.py
@@ -23,6 +23,7 @@ from prometheus_client import Summary
 CONF_PROMETHEUS_URL = 'prometheus_url'
 CONF_PROMETHEUS_QUERY = 'prometheus_query'
 CONF_STATE_CLASS = 'state_class'
+CONF_DEVICE_CLASS = 'device_class'
 CONF_UNIQUE_ID = 'unique_id'
 SCAN_INTERVAL = timedelta(seconds=600)
 
@@ -35,6 +36,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_NAME): cv.string,
     vol.Optional(CONF_UNIT_OF_MEASUREMENT): cv.string,
     vol.Optional(CONF_STATE_CLASS): STATE_CLASSES_SCHEMA,
+    vol.Optional(CONF_DEVICE_CLASS): DEVICE_CLASSES_SCHEMA,
     vol.Optional(CONF_UNIQUE_ID): cv.string,
 })
 
@@ -46,6 +48,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         'name': str(config.get(CONF_NAME)),
         'unit': str(config.get(CONF_UNIT_OF_MEASUREMENT)),
         'state_class': str(config.get(CONF_STATE_CLASS)),
+        'device_class': str(config.get(CONF_DEVICE_CLASS)),
         'unique_id': str(config.get(CONF_UNIQUE_ID)),
     }
 
@@ -62,6 +65,7 @@ class PrometheusQuery(SensorEntity):
         self._state = None
         self._attr_native_unit_of_measurement = prom_data["unit"]
         self._attr_state_class = prom_data["state_class"]
+        self._attr_device_class = prom_data["device_class"]
         self._attr_unique_id = f"${prom_data['url']}$${prom_data['query']}"
         if prom_data["unique_id"] is not None:
             self._attr_unique_id = prom_data["unique_id"]


### PR DESCRIPTION
The optional device_class field is required for the "Electrical Grid" integration, as it requires sensors with the 
`device_class: "energy"`

example compatible config
```
sensor:
  - platform: prometheus_query
    name: kWh used last hour
    unique_id: power_kWh_1h
    prometheus_url: http://192.168.1.124:9090
    prometheus_query: ceil( (1/3600 * sum_over_time(apparent_power{device="mainspower",instance="192.168.1.123:80",job="powermonitor",location="home"}[1h]) / 1000) * 1000 ) / 1000
    state_class: measurement
    device_class: energy
    unit_of_measurement: "kWh"
 ```
    
    Example of sensor now appearing in the grid consumption configuration
![image](https://user-images.githubusercontent.com/2709270/144726272-7d2b9cff-26d3-49fe-9cf3-ae8887b3e80c.png)
