### PR TITLE
Fix for incompatible versioning of requests package

### DIFF
--- a/custom_components/prometheus_query/manifest.json
+++ b/custom_components/prometheus_query/manifest.json
@@ -5,6 +5,6 @@
   "documentation": "https://github.com/lfasci/homeassistant-prometheus-query",
   "issue_tracker": "https://github.com/lfasci/homeassistant-prometheus-query",
   "codeowners": ["lfasci"],
-  "requirements": ["prometheus-client==0.9.0", "requests==2.27.1"],
+  "requirements": ["prometheus-client==0.9.0", "requests>=2.27.1"],
   "iot_class": "local_polling"
 }


### PR DESCRIPTION
Plugin failing to load on recent home-assitant version due to an incompatible version of the "requests" python package.  Fixed by changing the prometheus-query manifest to allow more recent versions of "requests" as well as the baseline requirement.